### PR TITLE
Match files within matched directories, even within nested subdirectories

### DIFF
--- a/gitignorant/__init__.py
+++ b/gitignorant/__init__.py
@@ -178,15 +178,19 @@ def check_path_match(
     * Split `path` into directory and file parts using the `split_path` function.
     * Check whether the directory part matches any directory rule,
       and if it does, consider that the result.
+    * If the directory part has parent directories, split the directory again using
+     `split_path` and repeat previous step. This repeats until all parent directories
+      have been checked.
     * Check whether the full path matches any file rule.
     """
 
     dirname, basename = split_path(path)
 
-    if dirname:
+    while dirname:
         dir_match = _find_match(rules, dirname, is_dir=True)
         if dir_match is not None:
             return dir_match
+        dirname, basename = split_path(dirname)
     return check_match(rules, path, is_dir=False)
 
 

--- a/test_gitignorant.py
+++ b/test_gitignorant.py
@@ -29,6 +29,8 @@ zz*
 # Directory testing
 recipes/
 !/other/recipes/
+notes/private
+!recipes/include_anyway
 
 # Escape testing
 \!important*
@@ -180,6 +182,23 @@ CHECK_PATH_MATCH_CASES = [
     # and it's not anchored to the root
     ("recipes/zep", True),
     ("splop/recipes/zep", True),
+    # all subdirectories and files inside subdirectories too
+    ("recipes/xoop/", True),
+    ("recipes/xoop/zep", True),
+    ("recipes/xoop/zep/", True),
+    ("recipes/pkex/pox/ioa/hai/kxr/aha", True),
+    ("splop/recipes/xoop/xep", True),
+    # Subdirectory match (`notes/private`) also catches everything under it,
+    # including further subdirectories
+    ("notes/private", True),
+    ("notes/private/ramblings/trees", True),
+    ("notes/private/free_stuff", True),
+    # However, subdirectory match is only relative to the .gitignore location and
+    # not any subdirectories
+    ("splop/notes/private/notes_on_splop", False),
+    # Negative rule on a nested file inside a positive rule matching path denies match
+    ("recipes/include_anyway/delicious_plum_pie.txt", False),
+    ("recipes/include_anyway/more_pie_recipes/rhubarb_pie.txt", False),
     # This should not match, since `/other/recipes/` is explicitly negated
     ("other/recipes/zep", False),
     # This too should match, since it's trying to ignore the whole folder

--- a/test_gitignorant.py
+++ b/test_gitignorant.py
@@ -29,6 +29,7 @@ zz*
 # Directory testing
 recipes/
 !/other/recipes/
+/other/recipes/work_in_progress.txt
 notes/private
 !recipes/include_anyway
 
@@ -193,14 +194,17 @@ CHECK_PATH_MATCH_CASES = [
     ("notes/private", True),
     ("notes/private/ramblings/trees", True),
     ("notes/private/free_stuff", True),
+    # It is not possible to explicitly include files from within an ignored directory
+    # (Git doesn't descend into ignored directories)
+    ("recipes/include_anyway/delicious_plum_pie.txt", True),
+    ("recipes/include_anyway/more_pie_recipes/rhubarb_pie.txt", True),
     # However, subdirectory match is only relative to the .gitignore location and
     # not any subdirectories
     ("splop/notes/private/notes_on_splop", False),
-    # Negative rule on a nested file inside a positive rule matching path denies match
-    ("recipes/include_anyway/delicious_plum_pie.txt", False),
-    ("recipes/include_anyway/more_pie_recipes/rhubarb_pie.txt", False),
     # This should not match, since `/other/recipes/` is explicitly negated
     ("other/recipes/zep", False),
+    # We can however re-ignore a file within an explicitly included directory
+    ("other/recipes/work_in_progress.txt", True),
     # This too should match, since it's trying to ignore the whole folder
     ("recipes/", True),
 ]


### PR DESCRIPTION
Path matcher would only check the immediate directory path of the file path given for matches, not all parent directories. We will now check all parent directories from least specific to most specific for matching rules, which lets you define a broad directory ignore and it will reliably match and therefore ignore everything under it. This improves parity with Git's ignore behaviour.

Inclusion rules can also include directories that would be otherwise ignored, but cannot include files or directories within those directories. Git does not descend into ignored directories.

It is also possible to ignore files again from directories previously included with an explicit inclusion rule, as per Git behaviour:

.gitignore
```
foo
!included/foo
included/foo/bar.txt
```

directory:
```
foo/
foo/bar.txt
included/foo/
included/foo/bar.txt
included/foo/quux.txt
```

git behaviour:
```
% git add -n .
add '.gitignore'
add 'included/foo/quux.txt'
```

A number of new test cases have been introduced for use cases described above.