### PR TITLE
Configure publishing via CI (using a trusted publisher)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
   push:
     branches:
       - master
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - master
@@ -27,6 +29,10 @@ jobs:
       - run: pip install -U build pytest pytest-cov
       - run: py.test -vvv --cov .
       - run: python -m build .
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist/
   Lint:
     runs-on: ubuntu-latest
     steps:
@@ -35,3 +41,24 @@ jobs:
         with:
           python-version: '3.11'
       - uses: pre-commit/action@v3.0.0
+  Publish:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    needs:
+      - Build
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+      url: https://pypi.org/p/gitignorant/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist/
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+          print-hash: true


### PR DESCRIPTION
The Trusted Publisher has already been configured in PyPI, so after merging this, pushing a new tag should now cause an automagical secure tokenless awesome publish.

This mirrors what was done in https://github.com/valohai/django-allauth-2fa/pull/166