### PR TITLE
Fix treating excludes without path as directories

### DIFF
--- a/gitignorant/__init__.py
+++ b/gitignorant/__init__.py
@@ -187,7 +187,7 @@ def check_path_match(
     """
 
     dirname, _ = split_path(path)
-    dir_parts = dirname.split(os.sep)
+    dir_parts = [part for part in dirname.split(os.sep) if part]
     path_to_match = ""
 
     for part in dir_parts:

--- a/test_gitignorant.py
+++ b/test_gitignorant.py
@@ -213,3 +213,30 @@ CHECK_PATH_MATCH_CASES = [
 @pytest.mark.parametrize(["path", "expected"], CHECK_PATH_MATCH_CASES)
 def test_check_path_match(rules: List[Rule], path: str, expected: bool) -> None:
     assert check_path_match(rules, path) == expected
+
+
+IGNORE_ALL_BY_DEFAULT_RULES = list(
+    parse_gitignore_file(
+        [
+            "*",
+            "!include_this",
+            "!included_subdir/",
+            "!included_subdir/*",
+            "!*wildcard",
+        ]
+    )
+)
+
+
+@pytest.mark.parametrize(
+    "path, expected",
+    [
+        ("ignore_this", True),
+        ("include_this", False),
+        ("included_subdir/include_file_in_subdir", False),
+        ("include_with_wildcard", False),
+    ],
+)
+def test_ignore_all_but_excluded(path: str, expected: bool) -> None:
+    """Test that we can ignore all files except those explicitly included"""
+    assert check_path_match(IGNORE_ALL_BY_DEFAULT_RULES, path) == expected


### PR DESCRIPTION
If no path was specified (i.e. just excluding a filename in `.vhignore`), split returned `[""]`, which then matched and caused the rule to be treated as a directory (and skipping filename matching).

This prevented rules like this working in `.vsignore`:

```gitignore
*
!exclude-this-file-from-ignore
```