### PR TITLE
Add development environment tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.PHONY: dev test
+
+# install the development dependencies
+dev: pyproject.toml
+	pip install -e .[dev]
+
+# run tests
+test:
+	pytest

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
+# use 'uv' to manage virtual environment if available
+UV := $(shell command -v uv)
+
 .PHONY: dev test
 
 # install the development dependencies
 dev: pyproject.toml
-	pip install -e .[dev]
+	$(UV) pip install -e .[dev]
 
 # run tests
 test:

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ UV := $(shell command -v uv)
 # install the development dependencies
 dev: pyproject.toml
 	$(UV) pip install -e .[dev]
+	pre-commit install
 
 # run tests
 test:

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,25 @@ dev: pyproject.toml
 # run tests
 test:
 	pytest
+
+.PHONY: lint format ruff debug-statements mypy
+
+# lint the code
+lint: ruff debug-statements mypy
+
+# reformat code
+format:
+	pre-commit run ruff-format --all-files
+	pre-commit run end-of-file-fixer --all-files
+	pre-commit run trailing-whitespace --all-files
+
+# individual linting tools
+
+ruff:
+	pre-commit run ruff --all-files
+
+debug-statements:
+	pre-commit run debug-statements --all-files
+
+mypy:
+	pre-commit run mypy --all-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,11 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest"
+]
+
 [project.urls]
 "Bug Tracker" = "https://github.com/valohai/gitignorant/issues"
 Homepage = "https://github.com/valohai/gitignorant"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest"
+    "pre-commit",
+    "pytest",
 ]
 
 [project.urls]


### PR DESCRIPTION
Add some helpers for managing the development environment:

- `make dev` installs the development tools (`pytest` and `pre-commit`) into the current virtual environment
  - uses `uv` if it is available, `pip` as a fallback
- `make test` runs the tests
- `make format` formats the code with tools specified in the pre-commit hooks
- `make lint` runs the linting tools specified in the pre-commit hooks
